### PR TITLE
Use explicit visibility for constants

### DIFF
--- a/src/TingBundle/TingBundle.php
+++ b/src/TingBundle/TingBundle.php
@@ -28,5 +28,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TingBundle extends Bundle
 {
-    const VERSION = '3.2';
+    public const VERSION = '3.2';
 }


### PR DESCRIPTION
It's compatible with the minimum PHP version required in this bundle