### PR TITLE
Fix symfony deprecations

### DIFF
--- a/src/TingBundle/Cache/MetadataWarmer.php
+++ b/src/TingBundle/Cache/MetadataWarmer.php
@@ -71,7 +71,7 @@ class MetadataWarmer implements CacheWarmerInterface
      *
      * @param string $cacheDir The cache directory
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): array
     {
         $repositories = [];
         foreach ($this->repositories as $key => $bundle) {
@@ -95,7 +95,8 @@ class MetadataWarmer implements CacheWarmerInterface
             $cacheDir,
             $this->cacheFile
         );
-        $metadataCacheGenerator->createCache($repositories);
+
+        return [$metadataCacheGenerator->createCache($repositories)];
     }
 
     /**


### PR DESCRIPTION
This would avoid this deprecation to be triggered

```
[info] User Deprecated: Method "Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface::warmUp()" might add "array" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\TingBundle\Cache\MetadataWarmer" now to avoid errors or add an explicit @return annotation to suppress this message.
```