### PR TITLE
Add metadatas cache clear

### DIFF
--- a/src/TingBundle/Cache/MetadataClearer.php
+++ b/src/TingBundle/Cache/MetadataClearer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Cache;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+class MetadataClearer implements CacheClearerInterface
+{
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /** @var string */
+    private $cacheFile;
+
+    public function __construct(string $cacheFile, Filesystem $filesystem = null)
+    {
+        $this->cacheFile = $cacheFile;
+        $this->fileSystem = $filesystem ?: new Filesystem();
+    }
+
+    public function clear($cacheDir)
+    {
+        $this->fileSystem->remove($cacheDir . '/' . $this->cacheFile);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | N/A

When using cache:clear command after sf cache warmup, bundle's cache file is not deleted. This can be source of bug / incoherence if using cache warmup during development.

Adding a metadata cache clearer avoid this weird behavior.