### PR TITLE
Compatibility with SF 7, drop PHP 7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,14 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
           - 8.1
           - 8.2
+          - 8.3
+          - 8.4
         deps:
           - highest
           - lowest
         composer:
-          - v1
           - v2
     name: Unit tests (PHP ${{ matrix.php }}, composer ${{ matrix.composer }}, ${{ matrix.deps }} dependencies)
     steps:
@@ -36,10 +33,10 @@ jobs:
           extensions: bcmath, bz2, gettext, mbstring, memcached, mcrypt, mysqli, opcache, pdo_mysql, zip, pdo, intl, json, pdo_pgsql, pgsql, session, simplexml, xml
           tools: "composer:${{ matrix.composer }}, pecl"
 
-      - name: "Install ${{ matrix.dependencies }} dependencies with composer"
+      - name: "Install ${{ matrix.deps }} deps with composer"
         uses: "ramsey/composer-install@v2"
         with:
-          dependency-versions: "${{ matrix.dependencies }}"
+          dependency-versions: "${{ matrix.deps }}"
 
       - name: Run Atoum tests
         run: php vendor/bin/atoum

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 3.8.0 (unreleased):
     * Drop support for PHP < 8.1
+    * Allow SF 7
 
 3.7.0 (2023-03-29):
     * log to ting channel instead of app by default

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.8.0 (unreleased):
+    * Drop support for PHP < 8.1
+
 3.7.0 (2023-03-29):
     * log to ting channel instead of app by default
 

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "php": ">=7.2",
         "ccmbenchmark/ting": "^3.5",
         "doctrine/cache": "^1.10",
-        "symfony/validator": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0",
-        "symfony/stopwatch": "^4.4 || ^5.0 || ^6.0"
+        "symfony/validator": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/stopwatch": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "atoum/atoum": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "symfony-bundle",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "ccmbenchmark/ting": "^3.5",
         "doctrine/cache": "^1.10",
         "symfony/validator": "^4.4 || ^5.0 || ^6.0 || ^7.0",
@@ -14,7 +14,7 @@
         "symfony/stopwatch": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "atoum/atoum": "^4.0",
+        "atoum/atoum": "^4.2",
         "atoum/stubs": "^2.2"
     },
     "autoload": {

--- a/src/TingBundle/Cache/MetadataWarmer.php
+++ b/src/TingBundle/Cache/MetadataWarmer.php
@@ -73,10 +73,8 @@ class MetadataWarmer implements CacheWarmerInterface
 
     /**
      * Warms up the cache.
-     *
-     * @param string $cacheDir The cache directory
      */
-    public function warmUp($cacheDir): array
+    public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         $repositories = [];
         foreach ($this->repositories as $key => $bundle) {
@@ -107,7 +105,7 @@ class MetadataWarmer implements CacheWarmerInterface
     /**
      * @inheritdoc
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/TingBundle/DataCollector/TingCacheDataCollector.php
+++ b/src/TingBundle/DataCollector/TingCacheDataCollector.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class TingCacheDataCollector extends DataCollector implements LateDataCollectorInterface
 {
@@ -37,7 +38,7 @@ class TingCacheDataCollector extends DataCollector implements LateDataCollectorI
      */
     protected $cacheLogger  = null;
 
-    protected $data = [];
+    protected array|Data $data = [];
 
     public function __construct()
     {

--- a/src/TingBundle/DataCollector/TingDriverDataCollector.php
+++ b/src/TingBundle/DataCollector/TingDriverDataCollector.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class TingDriverDataCollector extends DataCollector implements LateDataCollectorInterface
 {
@@ -37,7 +38,7 @@ class TingDriverDataCollector extends DataCollector implements LateDataCollector
      */
     protected $driverLogger = null;
 
-    protected $data = [];
+    protected array|Data $data = [];
 
     public function __construct()
     {

--- a/src/TingBundle/DependencyInjection/Configuration.php
+++ b/src/TingBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('ting');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/TingBundle/Validator/Constraints/UniqueEntity.php
+++ b/src/TingBundle/Validator/Constraints/UniqueEntity.php
@@ -57,7 +57,7 @@ class UniqueEntity extends Constraint
     /**
      * @return string
      */
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }
@@ -65,15 +65,7 @@ class UniqueEntity extends Constraint
     /**
      * @return array
      */
-    public function getRequiredOptions()
-    {
-        return ['fields', 'repository'];
-    }
-
-    /**
-     * @return array
-     */
-    public function getDefaultOption()
+    public function getRequiredOptions(): array
     {
         return ['fields', 'repository'];
     }

--- a/tests/units/TingBundle/Validator/Constraints/UniqueEntity.php
+++ b/tests/units/TingBundle/Validator/Constraints/UniqueEntity.php
@@ -51,16 +51,4 @@ class UniqueEntity extends \atoum
                     ->isIdenticalTo(['fields', 'repository'])
         ;
     }
-
-    public function testGetDefaultOption()
-    {
-        $this->mockGenerator->orphanize('__construct');
-
-        $this
-            ->if($mockUniqueEntity = new \mock\CCMBenchmark\TingBundle\Validator\Constraints\UniqueEntity())
-            ->then
-                ->array($mockUniqueEntity->getDefaultOption())
-                    ->isIdenticalTo(['fields', 'repository'])
-        ;
-    }
 }

--- a/tests/units/TingBundle/Validator/Constraints/UniqueEntityValidator.php
+++ b/tests/units/TingBundle/Validator/Constraints/UniqueEntityValidator.php
@@ -279,18 +279,6 @@ class UniqueEntityValidator extends \atoum
         ;
     }
 
-    public function testGetDefaultOption()
-    {
-        $this->mockGenerator->orphanize('__construct');
-
-        $this
-            ->if($mockUniqueEntity = new \mock\CCMBenchmark\TingBundle\Validator\Constraints\UniqueEntity())
-            ->then
-                ->array($mockUniqueEntity->getDefaultOption())
-                    ->isIdenticalTo(['fields', 'repository'])
-        ;
-    }
-
     private function getMockMetadata()
     {
         $this->mockGenerator()->orphanize('__construct');


### PR DESCRIPTION
This pull requests allow installation on SF 7 and PHP 8.
It drops old PHP Versions as Union types are required on several signatures, which is available only since PHP 8.0.

**Changes:**
- Drop PHP 7 and 8.0
- Update atoum to 4.2
- Remove test for `getDefaultOption`: the implementation is buggy, type hints make that clear: it should return a `?string`, not an array. As it makes no sense, the code is removed.
- Update a few signatures
- Fixes workflow