### PR TITLE
Support for attributes

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -4,6 +4,9 @@ use \atoum\atoum;
 
 $report = $script->addDefaultReport();
 $coverageField = new atoum\report\fields\runner\coverage\html('Ting', __DIR__ . '/tests/coverage/');
+//$script->noCodeCoverageForClasses('Symfony\Component\DependencyInjection\Extension\Extension');
+$script->noCodeCoverageForClasses('Symfony\Component\Validator\Constraint', 'Symfony\Component\Validator\ConstraintValidator', 'Symfony\Component\DependencyInjection\Extension\Extension', 'Symfony\Component\HttpKernel\DependencyInjection\Extension');
+//$script->noCodeCoverageForClasses('Symfony\Component\Validator\ConstraintValidator');
 $coverageField->setRootUrl('file://' . __DIR__ . '/tests/coverage/index.html');
 $report->addField($coverageField);
 $runner->addTestsFromDirectory('tests/units');

--- a/.atoum.php
+++ b/.atoum.php
@@ -4,9 +4,7 @@ use \atoum\atoum;
 
 $report = $script->addDefaultReport();
 $coverageField = new atoum\report\fields\runner\coverage\html('Ting', __DIR__ . '/tests/coverage/');
-//$script->noCodeCoverageForClasses('Symfony\Component\DependencyInjection\Extension\Extension');
 $script->noCodeCoverageForClasses('Symfony\Component\Validator\Constraint', 'Symfony\Component\Validator\ConstraintValidator', 'Symfony\Component\DependencyInjection\Extension\Extension', 'Symfony\Component\HttpKernel\DependencyInjection\Extension');
-//$script->noCodeCoverageForClasses('Symfony\Component\Validator\ConstraintValidator');
 $coverageField->setRootUrl('file://' . __DIR__ . '/tests/coverage/index.html');
 $report->addField($coverageField);
 $runner->addTestsFromDirectory('tests/units');

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=8.1",
-        "ccmbenchmark/ting": "^3.5",
+        "ccmbenchmark/ting": "^3.10",
         "doctrine/cache": "^1.10",
         "symfony/validator": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "atoum/atoum": "^4.2",
-        "atoum/stubs": "^2.2"
+        "atoum/stubs": "^2.2",
+        "brick/geo": ">=0.5 <=1.0"
     },
     "autoload": {
         "psr-4" : {

--- a/src/TingBundle/DependencyInjection/TingExtension.php
+++ b/src/TingBundle/DependencyInjection/TingExtension.php
@@ -152,7 +152,9 @@ class TingExtension extends Extension
                 $newField['primary'] = true;
             }
 
-            try {
+            if (is_subclass_of($property->getType()->getName(), '\Brick\Geo\Geometry')) {
+                $newField['type'] = 'geometry';
+            } else {
                 $newField['type'] = match ($property->getType()->getName()) {
                     'string' => 'string',
                     'int' => 'int',
@@ -165,10 +167,6 @@ class TingExtension extends Extension
                     Uuid::class => 'uuid',
                     default => 'string'
                 };
-            } catch (\UnhandledMatchError) {
-                if (is_subclass_of($property->getType()->getName(), '\Brick\Geo\Geometry')) {
-                    $newField['type'] = 'geometry';
-                }
             }
 
             if ($mappingAttribute->getArguments()['serializer'] ?? false) {

--- a/src/TingBundle/DependencyInjection/TingExtension.php
+++ b/src/TingBundle/DependencyInjection/TingExtension.php
@@ -24,7 +24,11 @@
 
 namespace CCMBenchmark\TingBundle\DependencyInjection;
 
+use CCMBenchmark\Ting\Repository\Metadata;
+use CCMBenchmark\TingBundle\Schema\Column;
+use CCMBenchmark\TingBundle\Schema\Table;
 use Doctrine\Common\Cache\VoidCache;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -32,10 +36,11 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Uid\Uuid;
 
 class TingExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $xmlLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $xmlLoader->load('services.xml');
@@ -48,8 +53,16 @@ class TingExtension extends Extension
         $container->setParameter('ting.repositories', $config['repositories']);
         $container->setParameter('ting.connections', $config['connections']);
         $container->setParameter('ting.database_options', $config['databases_options']);
-
-
+        
+        $metadataRepository = $container->getDefinition('ting.metadatarepository');
+        if (method_exists($container, 'registerAttributeForAutoconfiguration') === true) {
+            // SF 5.4+
+            $container->registerAttributeForAutoconfiguration(Table::class, function(ChildDefinition $definition, Table $attribute, \ReflectionClass $reflector) use ($container, $metadataRepository): void {
+                $newMetadata = $this->getMetadata($reflector, $attribute);
+                $metadataRepository->addMethodCall('addMetadata', [$attribute->repository, $newMetadata]);
+            });
+        }
+        
         $definition = $container->getDefinition('ting.cache');
         if (isset($config['cache_provider']) === true) {
             $definition->addMethodCall('setCache', [new Reference($config['cache_provider'])]);
@@ -101,5 +114,69 @@ class TingExtension extends Extension
             $definition = $container->getDefinition('ting.cache_data_collector');
             $definition->addMethodCall('setCacheLogger', [$reference]);
         }
+    }
+
+    /**
+     * @param \ReflectionClass $reflector
+     * @param Table $attribute
+     * @return Definition
+     */
+    function getMetadata(\ReflectionClass $reflector, Table $attribute): Definition
+    {
+        $newMetadata = new Definition(Metadata::class);
+        $newMetadata->addArgument(new Reference('ting.serializerfactory'));
+        $newMetadata->addMethodCall('setEntity', [$reflector->name]);
+        $newMetadata->addMethodCall('setTable', [$attribute->name]);
+        $newMetadata->addMethodCall('setDatabase', [$attribute->database]);
+        $newMetadata->addMethodCall('setConnectionName', [$attribute->connection]);
+        $newMetadata->addMethodCall('setRepository', [$attribute->repository]);
+
+        foreach ($reflector->getProperties() as $property) {
+            $mappingAttributes = $property->getAttributes(Column::class, \ReflectionAttribute::IS_INSTANCEOF);
+            if (count($mappingAttributes) === 0) {
+                continue;
+            }
+            if (count($mappingAttributes) > 1) {
+                throw new \RuntimeException(sprintf('Property %s from class %s cannot have multiple mapping attributes, currently %d', $property->getName(), $attribute->name, count($mappingAttributes)));
+            }
+            $mappingAttribute = $mappingAttributes[0];
+
+            $newField = [
+                'fieldName' => $property->getName(),
+                'columnName' => $mappingAttribute->getArguments()['column'] ?? strtolower(preg_replace('/[A-Z]/', '_\\0', lcfirst($property->getName()))), // snake case by default in database
+            ];
+            if ($mappingAttribute->getArguments()['autoIncrement'] ?? false) {
+                $newField['autoIncrement'] = true;
+            }
+            if ($mappingAttribute->getArguments()['primary'] ?? false) {
+                $newField['primary'] = true;
+            }
+
+            try {
+                $newField['type'] = match ($property->getType()->getName()) {
+                    'string' => 'string',
+                    'int' => 'int',
+                    'float' => 'double',
+                    'bool' => 'bool',
+                    'array' => 'json',
+                    \DateTimeImmutable::class => 'datetime_immutable',
+                    \DateTime::class => 'datetime',
+                    \DateTimeZone::class => 'datetimezone',
+                    Uuid::class => 'uuid',
+                    default => 'string'
+                };
+            } catch (\UnhandledMatchError) {
+                if (is_subclass_of($property->getType()->getName(), '\Brick\Geo\Geometry')) {
+                    $newField['type'] = 'geometry';
+                }
+            }
+
+            if ($mappingAttribute->getArguments()['serializer'] ?? false) {
+                $newField['serializer'] = $mappingAttribute->getArguments()['serializer'];
+            }
+
+            $newMetadata->addMethodCall('addField', [$newField]);
+        }
+        return $newMetadata;
     }
 }

--- a/src/TingBundle/Resources/config/services.xml
+++ b/src/TingBundle/Resources/config/services.xml
@@ -25,12 +25,15 @@
         <service id="ting.metadatarepository" class="CCMBenchmark\Ting\MetadataRepository" public="true">
             <argument type="service" id="ting.serializerfactory" />
         </service>
+        <service id="CCMBenchmark\Ting\MetadataRepository" alias="ting.metadatarepository" />
 
         <service id="ting.serializerfactory" class="CCMBenchmark\Ting\Serializer\SerializerFactory" public="true">
         </service>
+        <service id="CCMBenchmark\Ting\Serializer\SerializerFactoryInterface" alias="ting.serializerfactory" />
 
         <service id="ting.queryfactory" class="CCMBenchmark\Ting\Query\QueryFactory" public="true">
         </service>
+        <service id="CCMBenchmark\Ting\Query\QueryFactory" alias="ting.queryfactory" />
 
         <service id="ting.driverlogger" synthetic="true" public="true">
         </service>
@@ -43,12 +46,14 @@
                 <argument>%ting.database_options%</argument>
             </call>
         </service>
+        <service alias="ting.connectionpool" id="CCMBenchmark\Ting\ConnectionPool" />
 
         <service id="ting.unitofwork" class="CCMBenchmark\Ting\UnitOfWork" public="true">
             <argument type="service" id="ting.connectionpool" />
             <argument type="service" id="ting.metadatarepository" />
             <argument type="service" id="ting.queryfactory" />
         </service>
+        <service id="CCMBenchmark\Ting\UnitOfWork" alias="ting.unitofwork" />
 
         <service id="ting.hydrator" class="CCMBenchmark\Ting\Repository\Hydrator" shared="false" public="true">
             <call method="setMetadataRepository">
@@ -73,9 +78,11 @@
             <argument type="service" id="ting.unitofwork" />
             <argument type="service" id="ting.hydrator" />
         </service>
+        <service id="CCMBenchmark\Ting\Repository\CollectionFactory" alias="ting.collectionfactory" />
 
         <service id="ting.cache" class="CCMBenchmark\Ting\Cache\Cache" public="true">
         </service>
+        <service id="Doctrine\Common\Cache\Cache" alias="ting.cache" />
 
         <service id="ting.driver_data_collector" class="CCMBenchmark\TingBundle\DataCollector\TingDriverDataCollector" public="true">
             <tag name="data_collector" template="@Ting/Collector/driverCollector.html.twig" id="ting.driver" />

--- a/src/TingBundle/Schema/Column.php
+++ b/src/TingBundle/Schema/Column.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Schema;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Column
+{
+    public function __construct(
+        $autoIncrement = false,
+        $primary = false,
+        $column = null,
+        $serializer = null
+    ) {
+        
+    }
+}

--- a/src/TingBundle/Schema/Table.php
+++ b/src/TingBundle/Schema/Table.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Schema;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Table
+{
+    public function __construct(public string $name, public string $connection, public string $database, public string $repository)
+    {
+        
+    }
+}

--- a/tests/fixtures/EntityWithAttributes.php
+++ b/tests/fixtures/EntityWithAttributes.php
@@ -2,6 +2,7 @@
 
 namespace tests\fixtures;
 
+use Brick\Geo\Point;
 use CCMBenchmark\TingBundle\Schema\Column;
 use CCMBenchmark\TingBundle\Schema\Table;
 
@@ -29,5 +30,6 @@ class EntityWithAttributes
     #[Column]
     public array $json;
     
-    
+    #[Column]
+    public Point $point;
 }

--- a/tests/fixtures/EntityWithAttributes.php
+++ b/tests/fixtures/EntityWithAttributes.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace tests\fixtures;
+
+use CCMBenchmark\TingBundle\Schema\Column;
+use CCMBenchmark\TingBundle\Schema\Table;
+
+#[Table('entity_with_attributes', 'default', 'default', 'default')]
+class EntityWithAttributes
+{
+    #[Column(autoIncrement: true, primary: true)]
+    public int $id;
+    
+    #[Column(column: 'field')]
+    public string $fieldWithSpecifiedColumnName;
+    
+    #[Column]
+    public string $fieldAsCamelCase;
+    
+    #[Column]
+    public \DateTimeImmutable $dateImmutable;
+    
+    #[Column]
+    public \DateTime $dateMutable;
+    
+    #[Column]
+    public \DateTimeZone $timeZone;
+    
+    #[Column]
+    public array $json;
+    
+    
+}

--- a/tests/fixtures/EntityWithAttributesRepository.php
+++ b/tests/fixtures/EntityWithAttributesRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ccmbenchmark\ting_bundle\tests\fixtures;
+
+use CCMBenchmark\Ting\Repository\Repository;
+
+class EntityWithAttributesRepository extends Repository
+{
+
+}

--- a/tests/units/TingBundle/DependencyInjection/TingExtension.php
+++ b/tests/units/TingBundle/DependencyInjection/TingExtension.php
@@ -81,7 +81,8 @@ class TingExtension extends \atoum
                     ['addField', [['fieldName' => 'dateImmutable', 'columnName' => 'date_immutable', 'type' => 'datetime_immutable']]],
                     ['addField', [['fieldName' => 'dateMutable', 'columnName' => 'date_mutable', 'type' => 'datetime']]],
                     ['addField', [['fieldName' => 'timeZone', 'columnName' => 'time_zone', 'type' => 'datetimezone']]],
-                    ['addField', [['fieldName' => 'json', 'columnName' => 'json', 'type' => 'json']]]
+                    ['addField', [['fieldName' => 'json', 'columnName' => 'json', 'type' => 'json']]],
+                    ['addField', [['fieldName' => 'point', 'columnName' => 'point', 'type' => 'geometry']]],
                 ])
         ;
     }

--- a/tests/units/TingBundle/DependencyInjection/TingExtension.php
+++ b/tests/units/TingBundle/DependencyInjection/TingExtension.php
@@ -24,7 +24,10 @@
 
 namespace tests\units\CCMBenchmark\TingBundle\DependencyInjection;
 
+use Symfony\Component\Config\FileLocatorInterface;
+use tests\fixtures\EntityWithAttributes;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class TingExtension extends \atoum
@@ -35,6 +38,51 @@ class TingExtension extends \atoum
         $this
             ->if($containerBuilder = new ContainerBuilder(new ParameterBag(['kernel.debug' => false])))
             ->then($this->newTestedInstance->load([], $containerBuilder))
+        ;
+    }
+    
+    public function testAutoConfigurationWithAttributes()
+    {
+        $fixtureInstance = new Definition(EntityWithAttributes::class);
+        $fixtureInstance->setAutowired(true);
+        $fixtureInstance->setAutoconfigured(true);
+        $fixtureInstance->setPublic(true);
+        $fileLocator = new Definition(FileLocatorInterface::class);
+        $fileLocator->setAutowired(true);
+        $fileLocator->setAutoconfigured(true);
+        $containerBuilder = new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+            'kernel.cache_dir' => sys_get_temp_dir()
+        ]));
+        if (!method_exists($containerBuilder, 'registerAttributeForAutoconfiguration')) {
+            // Method is only sf 5.4+
+            return;
+        }
+        $this
+            ->if($containerBuilder->setDefinition('entity_with_attributes', $fixtureInstance))
+            ->and($containerBuilder->setDefinition('file_locator', $fileLocator))
+            ->then($this->newTestedInstance->load([], $containerBuilder))
+            ->and($containerBuilder->compile())
+            ->and($calls = $containerBuilder->getDefinition('ting.metadatarepository')->getMethodCalls())
+            ->string($calls[0][0])
+                ->isEqualTo('addMetadata')
+            ->array($calls[0][1][1]->getMethodCalls())
+                ->isIdenticalTo([
+                    ['setEntity', ['tests\\fixtures\\EntityWithAttributes']],
+                    ['setTable',['entity_with_attributes']],
+                    ['setDatabase', ['default']],
+                    ['setConnectionName', ['default']],
+                    ['setRepository', ['default']],
+                    ['addField', [
+                        ['fieldName' => 'id', 'columnName' => 'id', 'autoIncrement' => true, 'primary' => true, 'type' => 'int']]
+                    ],
+                    ['addField', [['fieldName' => 'fieldWithSpecifiedColumnName', 'columnName' => 'field', 'type' => 'string']]],
+                    ['addField', [['fieldName' => 'fieldAsCamelCase', 'columnName' => 'field_as_camel_case', 'type' => 'string']]],
+                    ['addField', [['fieldName' => 'dateImmutable', 'columnName' => 'date_immutable', 'type' => 'datetime_immutable']]],
+                    ['addField', [['fieldName' => 'dateMutable', 'columnName' => 'date_mutable', 'type' => 'datetime']]],
+                    ['addField', [['fieldName' => 'timeZone', 'columnName' => 'time_zone', 'type' => 'datetimezone']]],
+                    ['addField', [['fieldName' => 'json', 'columnName' => 'json', 'type' => 'json']]]
+                ])
         ;
     }
 }


### PR DESCRIPTION
This pull requests is currently a work in progress to collect early feedback.

Main goal: supporting attributes to remove all the `initMetadata` logic.

This is actually working, more as a POC, with the following configuration (nothing else):

```yaml
#config/packages/ting.yaml
ting:
  connections:
    main:
      namespace: CCMBenchmark\Ting\Driver\Mysqli
      master:
        host: "%env(DATABASE_HOST)%"
        user: "%env(DATABASE_USER)%"
        password: "%env(DATABASE_PASSWORD)%"
        port: 3306
```

And the following entity:

```php
<?php

namespace App\Entity;

use CCMBenchmark\Ting\Entity\NotifyProperty;
use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
use CCMBenchmark\Ting\Schema;
use Symfony\Component\Uid\Uuid;
use Symfony\Component\Validator\Constraints as Assert;

#[Schema\Table(name: 'properties', connection: 'main', database: 'alke_analytics', repository: \App\Repository\Property::class)]
class Property implements NotifyPropertyInterface
{
    use NotifyProperty;
    
    #[Schema\Column(autoIncrement: true)]
    public ?int $id = null;

    #[Schema\Column]
    #[Assert\Length(min: 1, max: 64)]
    public ?string $org_code = null;

    #[Schema\Column]
    #[Assert\NotBlank]
    #[Assert\Length(min: 1, max: 255)]
    public ?string $name = null;

    #[Schema\Column]
    public ?\DateTimeZone $timezone = null;

    #[Schema\Column]
    #[Assert\Uuid(versions: 4)]
    #[Assert\NotBlank]
    public ?Uuid $property_id = null;

    #[Schema\Column]
    public ?\DateTime $created_at = null;

    #[Schema\Column]
    public ?\DateTime $deleted_at = null;
}
```

At this stage an empty Repository is still mandatory:

```php
<?php

namespace App\Repository;

use CCMBenchmark\Ting\Repository\Repository;

class Property extends Repository
{

}
```

As you can see, there is a couple of other improvements in the pull requests:
- Support for symfony/uid (uuid at least)
- Autowiring for Repository (thanks to the aliases on all required services)
- Move pimple to suggest
- Collection is now JsonSerializable, no need to call `iterator_to_array` when you want to `json_encode` a Collection
- New DateTimeZone Serializer
- A minimal poc to support public properties, but we need to workaround the `NotifyProperty` limitation, one way or another (open to suggestions)
- Fixed a bug in the QueryGenerator, to query `null` values

I would love to have feedback on those features (I know, a lot for one pull request ;) ) before I dig deeper and add tests :pray: 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Licence       | Apache-2.0

See ccmbenchmark/ting#88