### PR TITLE
Feature/user provider

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,10 +1,28 @@
 <?php
 
 use \atoum\atoum;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 
 $report = $script->addDefaultReport();
 $coverageField = new atoum\report\fields\runner\coverage\html('Ting', __DIR__ . '/tests/coverage/');
 $script->noCodeCoverageForClasses('Symfony\Component\Validator\Constraint', 'Symfony\Component\Validator\ConstraintValidator', 'Symfony\Component\DependencyInjection\Extension\Extension', 'Symfony\Component\HttpKernel\DependencyInjection\Extension');
 $coverageField->setRootUrl('file://' . __DIR__ . '/tests/coverage/index.html');
 $report->addField($coverageField);
-$runner->addTestsFromDirectory('tests/units');
+/**
+ * @var $runner \atoum\atoum\scripts\runner
+ */
+$testsDirectory = __DIR__ . '/tests/units/TingBundle';
+$subDirectories = glob($testsDirectory . '/*', GLOB_ONLYDIR);
+$files = glob($testsDirectory . '/*.php');
+
+if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+    // Exclude ArgumentResolver from tests, available only in SF6+
+    $subDirectories = array_filter($subDirectories, fn($directory) => $directory !== $testsDirectory . '/ArgumentResolver' );
+}
+foreach ($subDirectories as $directory) {
+    $runner->addTestsFromPattern($directory . '/*');
+}
+foreach ($files as $file) {
+    $runner->addTestsFromPattern($files);
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 3.9.0 (unreleased):
-    * Feature: Supports automatic value resolving in controllers (with or without MapEntity), see [https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php](Doctrine Bridge)
+    * Feature: (SF6.2+) Supports automatic value resolving in controllers (with or without MapEntity), see [https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php](Doctrine Bridge)
 
 3.8.1 (2025-01-06):
     * PHP 8.4: Implicit nullable parameters are now deprecated

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.9.0 (unreleased):
+    * Feature: Supports automatic value resolving in controllers (with or without MapEntity), see [https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php](Doctrine Bridge)
+
 3.8.1 (2025-01-06):
     * PHP 8.4: Implicit nullable parameters are now deprecated
     * Add return type matching SF 7 deprecation

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "atoum/atoum": "^4.2",
         "atoum/stubs": "^2.2",
         "brick/geo": ">=0.5 <=1.0",
-        "symfony/expression-language": "^7.2"
+        "symfony/expression-language": "^6.3 || ^7.2"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
         "atoum/atoum": "^4.2",
         "atoum/stubs": "^2.2",
         "brick/geo": ">=0.5 <=1.0",
-        "symfony/expression-language": "^6.3 || ^7.2"
+        "symfony/expression-language": "^6.3 || ^7.2",
+        "symfony/uid": "^6.0 || ^7.0",
+        "symfony/security-bundle": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require-dev": {
         "atoum/atoum": "^4.2",
         "atoum/stubs": "^2.2",
-        "brick/geo": ">=0.5 <=1.0"
+        "brick/geo": ">=0.5 <=1.0",
+        "symfony/expression-language": "^7.2"
     },
     "autoload": {
         "psr-4" : {

--- a/src/TingBundle/ArgumentResolver/EntityValueResolver.php
+++ b/src/TingBundle/ArgumentResolver/EntityValueResolver.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\ArgumentResolver;
+
+use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\MetadataRepository;
+use CCMBenchmark\Ting\Repository\Metadata;
+use CCMBenchmark\Ting\Repository\Repository;
+use CCMBenchmark\TingBundle\Attribute\MapEntity;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Heavily inspired by https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+ */
+
+final class EntityValueResolver implements ValueResolverInterface
+{
+    private MapEntity $defaults;
+    public function __construct(
+        private MetadataRepository  $metadataRepository,
+        private RepositoryFactory   $repositoryFactory,
+        private ?ExpressionLanguage $expressionLanguage = null,
+        ?MapEntity           $defaults = null,
+    ) {
+        $this->defaults = $defaults ?? new MapEntity();
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        if (\is_object($request->attributes->get($argument->getName()))) {
+            return [];
+        }
+
+        $options = $argument->getAttributes(MapEntity::class, ArgumentMetadata::IS_INSTANCEOF);
+        $options = ($options[0] ?? $this->defaults)->withDefaults($this->defaults, $argument->getType());
+
+        if (!$options->class || $options->disabled) {
+            return [];
+        }
+        $repository = null;
+
+        $this->metadataRepository->findMetadataForEntity($options->class, function (Metadata $metadata) use (&$repository) {
+            $repository = $this->repositoryFactory->get($metadata->getRepository());
+        }, fn () => null);
+        if ($repository === null) {
+            return [];
+        }
+        
+        $message = '';
+        if (null !== $options->expr) {
+            if (null === $object = $this->findViaExpression($repository, $request, $options)) {
+                $message = \sprintf(' The expression "%s" returned null.', $options->expr);
+            }
+            // find by identifier?
+        } elseif (false === $object = $this->find($repository, $request, $options, $argument)) {
+            // find by criteria
+            if (!$criteria = $this->getCriteria($request, $options, $argument)) {
+                return [];
+            }
+            try {
+                $object = $repository->getOneBy($criteria);
+            } catch (Exception $e) {
+                $object = null;
+            }
+        }
+
+        if (null === $object && !$argument->isNullable()) {
+            throw new NotFoundHttpException($options->message ?? (\sprintf('"%s" object not found by "%s".', $options->class, self::class).$message));
+        }
+
+        return [$object];
+    }
+
+    private function find(Repository $repository, Request $request, MapEntity $options, ArgumentMetadata $argument): false|object|null
+    {
+        if ($options->mapping || $options->exclude) {
+            return false;
+        }
+
+        $id = $this->getIdentifier($request, $options, $argument);
+        if (false === $id || null === $id) {
+            return $id;
+        }
+        if (\is_array($id) && \in_array(null, $id, true)) {
+            return null;
+        }
+        try {
+            return $repository->get($id, $options->forcePrimary);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    private function getIdentifier(Request $request, MapEntity $options, ArgumentMetadata $argument): mixed
+    {
+        if (\is_array($options->id)) {
+            $id = [];
+            foreach ($options->id as $field) {
+                // Convert "%s_uuid" to "foobar_uuid"
+                if (str_contains($field, '%s')) {
+                    $field = \sprintf($field, $argument->getName());
+                }
+
+                $id[$field] = $request->attributes->get($field);
+            }
+
+            return $id;
+        }
+
+        if ($options->id) {
+            return $request->attributes->get($options->id) ?? ($options->stripNull ? false : null);
+        }
+
+        $name = $argument->getName();
+
+        if ($request->attributes->has($name)) {
+            if (\is_array($id = $request->attributes->get($name))) {
+                return false;
+            }
+
+            foreach ($request->attributes->get('_route_mapping') ?? [] as $parameter => $attribute) {
+                if ($name === $attribute) {
+                    $options->mapping = [$name => $parameter];
+
+                    return false;
+                }
+            }
+
+            return $id ?? ($options->stripNull ? false : null);
+        }
+
+        if ($request->attributes->has('id')) {
+            return $request->attributes->get('id') ?? ($options->stripNull ? false : null);
+        }
+
+        return false;
+    }
+
+    private function getCriteria(Request $request, MapEntity $options, ArgumentMetadata $argument): array
+    {
+        if (!($mapping = $options->mapping) && \is_array($criteria = $request->attributes->get($argument->getName()))) {
+            foreach ($options->exclude as $exclude) {
+                unset($criteria[$exclude]);
+            }
+
+            if ($options->stripNull) {
+                $criteria = array_filter($criteria, static fn ($value) => null !== $value);
+            }
+
+            return $criteria;
+        } elseif (null === $mapping) {
+            throw new \RuntimeException("Auto-mapping is not supported for Ting entities. Declare the identifier using either the #[MapEntity] attribute or mapped route parameters.");
+        }
+        
+        if ($mapping && array_is_list($mapping)) {
+            $mapping = array_combine($mapping, $mapping);
+        }
+
+        foreach ($options->exclude as $exclude) {
+            unset($mapping[$exclude]);
+        }
+        if (!$mapping) {
+            return [];
+        }
+        
+        $criteria = [];
+
+        foreach ($mapping as $attribute => $field) {
+            $criteria[$field] = $request->attributes->get($attribute);
+        }
+
+        if ($options->stripNull) {
+            $criteria = array_filter($criteria, static fn ($value) => null !== $value);
+        }
+
+        return $criteria;
+    }
+
+    private function findViaExpression(Repository $repository, Request $request, MapEntity $options): object|iterable|null
+    {
+        if (!$this->expressionLanguage) {
+            throw new \LogicException(\sprintf('You cannot use the "%s" if the ExpressionLanguage component is not available. Try running "composer require symfony/expression-language".', __CLASS__));
+        }
+
+        $variables = array_merge($request->attributes->all(), [
+            'repository' => $repository,
+            'request' => $request,
+        ]);
+
+        try {
+            return $this->expressionLanguage->evaluate($options->expr, $variables);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+}

--- a/src/TingBundle/Attribute/MapEntity.php
+++ b/src/TingBundle/Attribute/MapEntity.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Attribute;
+
+use CCMBenchmark\TingBundle\ArgumentResolver\EntityValueResolver;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+
+/**
+ * Indicates that a controller argument should receive an Entity.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class MapEntity extends ValueResolver
+{
+    /**
+     * @param class-string|null          $class         The entity class
+     * @param string|null                $expr          An expression to fetch the entity using the {@see https://symfony.com/doc/current/components/expression_language.html ExpressionLanguage} syntax.
+     *                                                  Any request attribute are available as a variable, and your entity repository in the 'repository' variable.
+     * @param array<string, string>|null $mapping       Configures the properties and values to use with the getOneBy() method
+     *                                                  The key is the route placeholder name and the value is the property name
+     * @param string[]|null              $exclude       Configures the properties that should be used in the getOneBy() method by excluding
+     *                                                  one or more properties so that not all are used
+     * @param bool|null                  $stripNull     Whether to prevent null values from being used as parameters in the query (defaults to false)
+     * @param string[]|string|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key
+     * @param bool                       $forcePrimary    If true, forces Ting to always use the primary / master to retrieve the object
+     */
+    public function __construct(
+        public ?string $class = null,
+        public ?string $expr = null,
+        public ?array $mapping = null,
+        public ?array $exclude = null,
+        public ?bool $stripNull = null,
+        public array|string|null $id = null,
+        public bool $forcePrimary = false,
+        bool $disabled = false,
+        string $resolver = EntityValueResolver::class,
+        public ?string $message = null,
+    ) {
+        parent::__construct($resolver, $disabled);
+        $this->selfValidate();
+    }
+
+    public function withDefaults(self $defaults, ?string $class): static
+    {
+        $clone = clone $this;
+        $clone->class ??= class_exists($class ?? '') ? $class : null;
+        $clone->expr ??= $defaults->expr;
+        $clone->mapping ??= $defaults->mapping;
+        $clone->exclude ??= $defaults->exclude ?? [];
+        $clone->stripNull ??= $defaults->stripNull ?? false;
+        $clone->id ??= $defaults->id;
+        $clone->forcePrimary ??= $defaults->forcePrimary ?? false;
+        $clone->message ??= $defaults->message;
+
+        $clone->selfValidate();
+
+        return $clone;
+    }
+
+    private function selfValidate(): void
+    {
+        if (!$this->id) {
+            return;
+        }
+        if ($this->mapping) {
+            throw new \LogicException('The "id" and "mapping" options cannot be used together on #[MapEntity] attributes.');
+        }
+        if ($this->exclude) {
+            throw new \LogicException('The "id" and "exclude" options cannot be used together on #[MapEntity] attributes.');
+        }
+        $this->mapping = [];
+    }
+}

--- a/src/TingBundle/DependencyInjection/EntityFactory.php
+++ b/src/TingBundle/DependencyInjection/EntityFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\DependencyInjection;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class EntityFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, string $id, array $config): void
+    {
+        $container
+            ->setDefinition($id, new ChildDefinition('ting.security.user_provider'))
+            ->addArgument($config['class'])
+            ->addArgument($config['property'])
+        ;
+    }
+
+    public function getKey(): string
+    {
+        return 'ting';
+    }
+
+    public function addConfiguration(NodeDefinition $builder): void
+    {
+        $builder
+            ->children()
+                ->scalarNode('class')
+                    ->isRequired()
+                    ->info('The full entity class name of your user class.')
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('property')->defaultNull()->end()
+            ->end()
+        ;
+    }
+}

--- a/src/TingBundle/Resources/config/services.xml
+++ b/src/TingBundle/Resources/config/services.xml
@@ -106,12 +106,10 @@
             <argument type="service" id="ting" />
             <tag name="validator.constraint_validator" />
         </service>
-        
-        <service id="ting.entity_value_resolver" class="CCMBenchmark\TingBundle\ArgumentResolver\EntityValueResolver">
-            <tag name="controller.argument_value_resolver" priority="110" />
+
+        <service id="ting.security.user_provider" abstract="true" class="CCMBenchmark\TingBundle\Security\EntityUserProvider">
             <argument type="service" id="ting.metadatarepository" />
             <argument type="service" id="ting" />
-            <argument type="service" id="Symfony\Component\ExpressionLanguage\ExpressionLanguage" on-invalid="null" />
         </service>
     </services>
 </container>

--- a/src/TingBundle/Resources/config/services.xml
+++ b/src/TingBundle/Resources/config/services.xml
@@ -111,12 +111,7 @@
             <tag name="controller.argument_value_resolver" priority="110" />
             <argument type="service" id="ting.metadatarepository" />
             <argument type="service" id="ting" />
-            <argument type="service" id="Symfony\Component\ExpressionLanguage\ExpressionLanguage" on-invalid="null" /><!--
-            private MetadataRepository $metadataRepository,
-            private RepositoryFactory $repositoryFactory,
-            private ?ExpressionLanguage $expressionLanguage = null,
-            private MapEntity $defaults = new MapEntity(),-->
-
+            <argument type="service" id="Symfony\Component\ExpressionLanguage\ExpressionLanguage" on-invalid="null" />
         </service>
     </services>
 </container>

--- a/src/TingBundle/Resources/config/services.xml
+++ b/src/TingBundle/Resources/config/services.xml
@@ -106,5 +106,17 @@
             <argument type="service" id="ting" />
             <tag name="validator.constraint_validator" />
         </service>
+        
+        <service id="ting.entity_value_resolver" class="CCMBenchmark\TingBundle\ArgumentResolver\EntityValueResolver">
+            <tag name="controller.argument_value_resolver" priority="110" />
+            <argument type="service" id="ting.metadatarepository" />
+            <argument type="service" id="ting" />
+            <argument type="service" id="Symfony\Component\ExpressionLanguage\ExpressionLanguage" on-invalid="null" /><!--
+            private MetadataRepository $metadataRepository,
+            private RepositoryFactory $repositoryFactory,
+            private ?ExpressionLanguage $expressionLanguage = null,
+            private MapEntity $defaults = new MapEntity(),-->
+
+        </service>
     </services>
 </container>

--- a/src/TingBundle/Security/EntityUserProvider.php
+++ b/src/TingBundle/Security/EntityUserProvider.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Security;
+
+use CCMBenchmark\Ting\MetadataRepository;
+use CCMBenchmark\Ting\Repository\Metadata;
+use CCMBenchmark\Ting\Repository\Repository;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * @template TUser of UserInterface
+ *
+ * @template-implements UserProviderInterface<TUser>
+ */
+class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInterface
+{
+    public function __construct(
+        private readonly MetadataRepository $metadataRepository,
+        private readonly RepositoryFactory  $repositoryFactory,
+        private readonly string             $class,
+        private readonly ?string            $property = null,
+    ) {
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        $repository = $this->getRepository();
+        if (null !== $this->property) {
+            $user = $repository->getOneBy([$this->property => $identifier]);
+        } else {
+            if (!$repository instanceof UserLoaderInterface) {
+                throw new \InvalidArgumentException(\sprintf('You must either make the "%s" entity Ting Repository ("%s") implement "CCMBenchmark\TingBundle\Security\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.', $this->class, get_debug_type($repository)));
+            }
+
+            $user = $repository->loadUserByIdentifier($identifier);
+        }
+
+        if (null === $user) {
+            $e = new UserNotFoundException(\sprintf('User "%s" not found.', $identifier));
+            $e->setUserIdentifier($identifier);
+
+            throw $e;
+        }
+
+        return $user;
+    }
+
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof $this->class) {
+            throw new UnsupportedUserException(\sprintf('Instances of "%s" are not supported.', get_debug_type($user)));
+        }
+        
+        $repository = $this->getRepository();
+        if ($repository instanceof UserProviderInterface) {
+            $refreshedUser = $repository->refreshUser($user);
+        } else {
+            // The user must be reloaded via the primary key as all other data
+            // might have changed without proper persistence in the database.
+            // That's the case when the user has been changed by a form with
+            // validation errors.
+            if (!$id = $this->getIdentifierValues($user)) {
+                throw new \InvalidArgumentException('You cannot refresh a user from the EntityUserProvider that does not contain an identifier. The user object has to be serialized with its own identifier mapped by Doctrine.');
+            }
+
+            $refreshedUser = $repository->get($id);
+            if (null === $refreshedUser) {
+                $e = new UserNotFoundException('User with id '.json_encode($id).' not found.');
+                $e->setUserIdentifier(json_encode($id));
+
+                throw $e;
+            }
+        }
+
+        return $refreshedUser;
+    }
+
+    public function supportsClass(string $class): bool
+    {
+        return $class === $this->class || is_subclass_of($class, $this->class);
+    }
+
+    /**
+     * @final
+     */
+    public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
+    {
+        if (!$user instanceof $this->class) {
+            throw new UnsupportedUserException(\sprintf('Instances of "%s" are not supported.', get_debug_type($user)));
+        }
+
+        $repository = $this->getRepository();
+        if ($repository instanceof PasswordUpgraderInterface) {
+            $repository->upgradePassword($user, $newHashedPassword);
+        }
+    }
+    
+    private function getMetadata(): Metadata
+    {
+        $metadata = null;
+        $this->metadataRepository->findMetadataForEntity($this->class, function (Metadata $innerMetadata) use (&$metadata) {
+            $metadata = $innerMetadata;
+        }, fn () => null);
+        
+        if ($metadata === null) {
+            throw new \InvalidArgumentException(\sprintf('No metadata found for entity "%s".', $this->class));
+        }
+        
+        return $metadata;
+    }
+
+    private function getRepository(): Repository
+    {
+        return $this->repositoryFactory->get($this->getMetadata()->getRepository());
+    }
+    
+    private function getIdentifierValues($user): ?array
+    {
+        $metadata = $this->getMetadata();
+        $primaries = $metadata->getPrimaries();
+        if ($primaries === []) {
+            return null;
+        }
+        $identifierValues = [];
+        foreach ($primaries as $primary) {
+            $identifierValues[$primary] = $metadata->getEntityPropertyByFieldName($user, $primary);
+        }
+        
+        return $identifierValues;
+    }
+}

--- a/src/TingBundle/Security/UserLoaderInterface.php
+++ b/src/TingBundle/Security/UserLoaderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CCMBenchmark\TingBundle\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface UserLoaderInterface
+{
+    /**
+     * Loads the user for the given user identifier (e.g. username or email).
+     *
+     * This method must return null if the user is not found.
+     */
+    public function loadUserByIdentifier(string $identifier): ?UserInterface;
+}

--- a/src/TingBundle/TingBundle.php
+++ b/src/TingBundle/TingBundle.php
@@ -24,9 +24,20 @@
 
 namespace CCMBenchmark\TingBundle;
 
+use CCMBenchmark\TingBundle\DependencyInjection\EntityFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TingBundle extends Bundle
 {
     public const VERSION = '3.8';
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        
+        if ($container->hasExtension('security')) {
+            $container->getExtension('security')->addUserProviderFactory(new EntityFactory());
+        }
+    }
 }

--- a/tests/fixtures/EntityWithAttributesRepository.php
+++ b/tests/fixtures/EntityWithAttributesRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ccmbenchmark\ting_bundle\tests\fixtures;
+namespace tests\fixtures;
 
 use CCMBenchmark\Ting\Repository\Repository;
 

--- a/tests/fixtures/SimpleRepository.php
+++ b/tests/fixtures/SimpleRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace tests\fixtures;
+
+use CCMBenchmark\Ting\Repository\Repository;
+
+class SimpleRepository extends Repository
+{
+    public function __construct()
+    {
+        
+    }
+}

--- a/tests/units/TingBundle/ArgumentResolver/EntityValueResolver.php
+++ b/tests/units/TingBundle/ArgumentResolver/EntityValueResolver.php
@@ -10,11 +10,15 @@ use CCMBenchmark\Ting\Repository\Hydrator;
 use CCMBenchmark\Ting\Serializer\SerializerFactory;
 use CCMBenchmark\Ting\UnitOfWork;
 use CCMBenchmark\TingBundle\Attribute\MapEntity;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * @tags SF
+ */
 class EntityValueResolver extends atoum
 {
     private $metadataRepository;
@@ -49,6 +53,9 @@ class EntityValueResolver extends atoum
 
     public function testReturnsEmptyArrayWhenArgumentIsAlreadyObject(): void
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($request = new Request(['argumentName' => new \stdClass()]))
             ->and($argument = new ArgumentMetadata('argumentName', null, false, false, null))
@@ -62,6 +69,9 @@ class EntityValueResolver extends atoum
 
     public function testReturnsEmptyArrayWhenMapEntityIsDisabled(): void
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', disabled: true))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
@@ -76,6 +86,9 @@ class EntityValueResolver extends atoum
     
     public function testWithRouteMapping(): void
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($argumentCity = $this->createArgumentMetadataForAttributes(new MapEntity(class: 'City'), 'city'))
             ->and($argumentCountry = $this->createArgumentMetadataForAttributes(new MapEntity(class: 'Country'), 'country'))
@@ -105,6 +118,9 @@ class EntityValueResolver extends atoum
 
     public function testThrowsNotFoundHttpExceptionWhenObjectCannotBeFound(): void
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $simpleRepository = new \mock\tests\fixtures\SimpleRepository();
         $this->calling($simpleRepository)->get = null;
         $this
@@ -125,6 +141,9 @@ class EntityValueResolver extends atoum
 
     public function testReturnsObjectWhenFoundInRepository()
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', id: 'id'))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
@@ -144,6 +163,9 @@ class EntityValueResolver extends atoum
 
     public function testEvaluatesExpressionWhenProvided()
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', expr: 'repository.find(id)'))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
@@ -163,6 +185,9 @@ class EntityValueResolver extends atoum
     
     public function testExpressionFailureReturns404()
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', expr: 'repository.find(id)'))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
@@ -180,6 +205,9 @@ class EntityValueResolver extends atoum
 
     public function testReturnsEmptyArrayWhenCriteriaCannotBeDetermined()
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', mapping: []))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
@@ -198,6 +226,9 @@ class EntityValueResolver extends atoum
     
     public function testReturnsObjectWhenCriteriaCanBeDetermined()
     {
+        if (!interface_exists(ValueResolverInterface::class) || !class_exists(ValueResolver::class)) {
+            return;
+        }
         $this
             ->given($mapEntity = new MapEntity(class: 'TestEntity', mapping: ['name' => 'name', 'id' => 'id']))
             ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))

--- a/tests/units/TingBundle/ArgumentResolver/EntityValueResolver.php
+++ b/tests/units/TingBundle/ArgumentResolver/EntityValueResolver.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace tests\units\CCMBenchmark\TingBundle\ArgumentResolver;
+
+use atoum;
+use CCMBenchmark\Ting\ConnectionPool;
+use CCMBenchmark\Ting\Query\QueryFactory;
+use CCMBenchmark\Ting\Repository\CollectionFactory;
+use CCMBenchmark\Ting\Repository\Hydrator;
+use CCMBenchmark\Ting\Serializer\SerializerFactory;
+use CCMBenchmark\Ting\UnitOfWork;
+use CCMBenchmark\TingBundle\Attribute\MapEntity;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class EntityValueResolver extends atoum
+{
+    private $metadataRepository;
+    private $repositoryFactory;
+    private $expressionLanguage;
+    private $resolver;
+
+    public function beforeTestMethod($method)
+    {
+        $this->metadataRepository = new \mock\CCMBenchmark\Ting\MetadataRepository(new SerializerFactory());
+        $connectionPool = new ConnectionPool();
+        $queryFactory = new QueryFactory();
+        $unitOfWork = new UnitOfWork($connectionPool, $this->metadataRepository, $queryFactory);
+        $hydrator = new Hydrator();
+        $this->repositoryFactory = new \mock\CCMBenchmark\TingBundle\Repository\RepositoryFactory(
+            $connectionPool,
+            $this->metadataRepository,
+            new QueryFactory(),
+            new CollectionFactory($this->metadataRepository, $unitOfWork, $hydrator),
+            $unitOfWork,
+            new \CCMBenchmark\Ting\Cache\Cache(),
+            new SerializerFactory()
+        );
+        $this->expressionLanguage = new \mock\Symfony\Component\ExpressionLanguage\ExpressionLanguage();
+
+        $this->resolver = new \CCMBenchmark\TingBundle\ArgumentResolver\EntityValueResolver(
+            $this->metadataRepository,
+            $this->repositoryFactory,
+            $this->expressionLanguage
+        );
+    }
+
+    public function testReturnsEmptyArrayWhenArgumentIsAlreadyObject(): void
+    {
+        $this
+            ->given($request = new Request(['argumentName' => new \stdClass()]))
+            ->and($argument = new ArgumentMetadata('argumentName', null, false, false, null))
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->isEmpty();
+    }
+
+    public function testReturnsEmptyArrayWhenMapEntityIsDisabled(): void
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', disabled: true))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request())
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->isEmpty();
+    }
+    
+    public function testWithRouteMapping(): void
+    {
+        $this
+            ->given($argumentCity = $this->createArgumentMetadataForAttributes(new MapEntity(class: 'City'), 'city'))
+            ->and($argumentCountry = $this->createArgumentMetadataForAttributes(new MapEntity(class: 'Country'), 'country'))
+            ->and($request = new Request(attributes: ['city' => 'Paris', 'country' => 'France', '_route_mapping' => ['slug' => 'city', 'country' => 'country']]))
+            ->and($city = new \stdClass())
+            ->and($country = new \stdClass())
+            
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->calling($repository)->getOneBy = static fn($criteria) => match($criteria) {
+                ['slug' => 'Paris'] => $city,
+                ['country' => 'France'] => $country,
+            } )
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+
+            ->when($result = $this->resolver->resolve($request, $argumentCity))
+            ->then
+                ->array($result)
+                ->hasSize(1)
+                ->contains($city)
+            ->when($result = $this->resolver->resolve($request, $argumentCountry))
+            ->then
+                ->array($result)
+                ->hasSize(1)
+                ->contains($country)
+        ;
+    }
+
+    public function testThrowsNotFoundHttpExceptionWhenObjectCannotBeFound(): void
+    {
+        $simpleRepository = new \mock\tests\fixtures\SimpleRepository();
+        $this->calling($simpleRepository)->get = null;
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', id: 'id'))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request(attributes: ['id' => 123]))
+
+            ->and($this->calling($this->metadataRepository)->findMetadataForEntity =
+                fn($class, $success) => $success(new \mock\CCMBenchmark\Ting\Repository\Metadata(new SerializerFactory())))
+
+            ->and($this->calling($this->repositoryFactory)->get = $simpleRepository)
+
+            ->exception(function () use ($request, $argument) {
+                $this->resolver->resolve($request, $argument);
+            })
+            ->isInstanceOf(NotFoundHttpException::class);
+    }
+
+    public function testReturnsObjectWhenFoundInRepository()
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', id: 'id'))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request(attributes: ['id' => 123]))
+
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->calling($repository)->get = $object = new \stdClass())
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->hasSize(1)
+            ->contains($object);
+    }
+
+    public function testEvaluatesExpressionWhenProvided()
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', expr: 'repository.find(id)'))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request(attributes: ['id' => 123]))
+
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+            ->and($this->calling($this->expressionLanguage)->evaluate = $object = new \stdClass())
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->hasSize(1)
+            ->contains($object);
+    }
+    
+    public function testExpressionFailureReturns404()
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', expr: 'repository.find(id)'))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request(attributes: ['id' => 123]))
+
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+            ->and($this->calling($this->expressionLanguage)->evaluate = null)
+
+            ->exception(function () use ($request, $argument) {
+                $this->resolver->resolve($request, $argument);
+            })
+            ->isInstanceOf(NotFoundHttpException::class);
+    }
+
+    public function testReturnsEmptyArrayWhenCriteriaCannotBeDetermined()
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', mapping: []))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request())
+
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->calling($repository)->getOneBy->doesNothing())
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->isEmpty();
+    }
+    
+    public function testReturnsObjectWhenCriteriaCanBeDetermined()
+    {
+        $this
+            ->given($mapEntity = new MapEntity(class: 'TestEntity', mapping: ['name' => 'name', 'id' => 'id']))
+            ->and($argument = $this->createArgumentMetadataForAttributes($mapEntity))
+            ->and($request = new Request(attributes: ['id' => 123, 'name' => 'foo']))
+
+            ->and($repository = new \mock\tests\fixtures\SimpleRepository())
+            ->and($this->calling($repository)->getOneBy = $object = new \stdClass())
+            ->and($this->mockRepositoryFactoryAndMetadata($repository))
+
+            ->when($result = $this->resolver->resolve($request, $argument))
+
+            ->then
+            ->array($result)
+            ->hasSize(1)
+            ->contains($object);
+    }
+
+    private function createArgumentMetadataForAttributes(MapEntity $attribute, string $argumentName = 'argumentName'): ArgumentMetadata
+    {
+        return new ArgumentMetadata($argumentName, $attribute->class, false, false, null, false, [$attribute]);
+    }
+
+    private function mockRepositoryFactoryAndMetadata($repository): void
+    {
+        $metadata = new \mock\CCMBenchmark\Ting\Repository\Metadata(new SerializerFactory());
+        $this->calling($metadata)->getRepository = 'RepositoryClass';
+
+        $this->calling($this->metadataRepository)->findMetadataForEntity =
+            fn($class, $success) => $success($metadata);
+
+        $this->calling($this->repositoryFactory)->get = $repository;
+    }
+}

--- a/tests/units/TingBundle/DependencyInjection/TingExtension.php
+++ b/tests/units/TingBundle/DependencyInjection/TingExtension.php
@@ -32,15 +32,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class TingExtension extends \atoum
 {
-    public function testEmpty()
-    {
-        // Minimum test to ensure code execution
-        $this
-            ->if($containerBuilder = new ContainerBuilder(new ParameterBag(['kernel.debug' => false])))
-            ->then($this->newTestedInstance->load([], $containerBuilder))
-        ;
-    }
-    
     public function testAutoConfigurationWithAttributes()
     {
         $fixtureInstance = new Definition(EntityWithAttributes::class);
@@ -84,6 +75,17 @@ class TingExtension extends \atoum
                     ['addField', [['fieldName' => 'json', 'columnName' => 'json', 'type' => 'json']]],
                     ['addField', [['fieldName' => 'point', 'columnName' => 'point', 'type' => 'geometry']]],
                 ])
+        ;
+    }
+    
+    public function testContainerShouldDeclareValueResolverIfAvailable()
+    {
+        $this
+            ->if($containerBuilder = new ContainerBuilder(new ParameterBag(['kernel.debug' => false])))
+            ->then($this->newTestedInstance->load([], $containerBuilder))
+            ->and($shouldBeDeclared = interface_exists(ValueResolverInterface::class) && class_exists(ValueResolver::class))
+                ->boolean($containerBuilder->hasDefinition('ting.argumentvalueresolver'))
+                    ->isEqualTo($shouldBeDeclared)
         ;
     }
 }


### PR DESCRIPTION
With that feature you can use a Ting Entity directly in your main security configuration:

```
security:
    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
    password_hashers:
        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
    providers:
        app_user_provider:
            ting:
                class: App\Entity\User
                property: email
```

Your entity will have to implements the following interfaces: `Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface` (for password authenticated users) and `Symfony\Component\Security\Core\User\UserInterface` (common to all kind of users).

You'll have to implement `__serialize` also.
