### PR TITLE
The constraint UniqueEntity can now be used with an attribute on your class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.9.0 (unreleased):
+    * The constraint "UniqueEntity" can now be used with an attribute on your class
+
 3.8.2 (2025-01-09):
     * Fix: better detection for Uuid subclasses in autowiring
 

--- a/src/TingBundle/Validator/Constraints/UniqueEntity.php
+++ b/src/TingBundle/Validator/Constraints/UniqueEntity.php
@@ -32,6 +32,7 @@ use Symfony\Component\Validator\Constraint;
  * @Annotation
  * @Target({"CLASS", "ANNOTATION"})
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class UniqueEntity extends Constraint
 {
     /**


### PR DESCRIPTION
Example:

```php
<?php

namespace App\Entity;

use App\Repository\UserRepository;
use CCMBenchmark\Ting\Entity\NotifyProperty;
use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
use CCMBenchmark\TingBundle\Schema\Column;
use CCMBenchmark\TingBundle\Schema\Table;
use CCMBenchmark\TingBundle\Validator\Constraints\UniqueEntity;
use Symfony\Component\Serializer\Attribute\Groups;
use Symfony\Component\Uid\UuidV4;
use Symfony\Component\Validator\Constraints as Assert;

#[Table(name: 'users', connection: 'main', database: '%env(DATABASE_DB_NAME)%', repository: UserRepository::class)]
#[UniqueEntity(options:['repository' => UserRepository::class, 'fields' => ['email']], groups: ['create'])]
class User implements NotifyPropertyInterface
{
    use NotifyProperty;
    
    #[Column(autoIncrement: true, primary: true)]
    public int $id { set(int $id) {
        $this->propertyChanged('id', $this->id ?? null, $id);
        $this->id = $id;
    }}
    
    #[Column]
    #[Groups(['default', 'service_account'])]
    public UuidV4 $userId { set(UuidV4 $userId) {
        $this->propertyChanged('userId', $this->userId ?? null, $userId);
        $this->userId = $userId;
    }}
        
    #[Column]
    #[Groups(['default', 'create', 'update', 'service_account'])]
    #[Assert\NotBlank(groups: ["default", "create", "update"])]
    #[Assert\Email(groups: ["default", "create", "update"])]
    public string $email { set(string $email) {
        $this->propertyChanged('email', $this->email ?? null, $email);
        $this->email = $email;
    } }
}

```